### PR TITLE
Enum for classification types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 venv*
 config.py
+data/
+models/

--- a/src/class_enum.py
+++ b/src/class_enum.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class ClassEnum(Enum):
+    """
+    See this subreddit FAQ for more about these label types
+    https://www.reddit.com/r/AmItheAsshole/wiki/faq#wiki_what.2019s_with_these_acronyms.3F_what_do_they_mean.3F
+    """
+    NTA = 0  # not the asshole
+    YTA = 1  # you're the asshole
+    ESH = 2  # everyone sucks here
+    NAH = 3  # no assholes here
+    INFO = 4  # not enough info to determine

--- a/src/model.py
+++ b/src/model.py
@@ -10,7 +10,7 @@ class AssholeClassifier(pl.LightningModule):
     def __init__(self, learning_rate, possible_labels):
         super().__init__()
         self.model = BertForSequenceClassification.from_pretrained('bert-base-uncased',
-                                                                   num_labels=2,
+                                                                   num_labels=len(possible_labels),
                                                                    output_attentions=False,
                                                                    output_hidden_states=False)
         self.learning_rate = learning_rate

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,19 +1,17 @@
 '''
 algorithm to pull data from reddit,
-determine whether the poster is an asshole based on the commenters annotattions,
+determine whether the poster is an asshole based on the comments,
 and output to file
 (maybe link with EC2?)
 '''
-import praw
+import csv
+import logging
+from pathlib import Path
 
+import praw
 from praw.models import MoreComments
 
 from src import config
-from pathlib import Path
-import csv
-import logging
-import datetime
-from psaw import PushshiftAPI
 
 
 def does_commenter_think_OP_is_an_ass(comment_text: str) -> bool:
@@ -40,6 +38,9 @@ def is_asshole(submission: praw.models.reddit.submission.Submission):
     votes_for_NTA = 0
     votes_for_YTA = 0
 
+    upvotes_for_NTA = 0
+    upvotes_for_YTA = 0
+
     # This submission’s comment forest contains a number of MoreComments objects.
     # These objects represent the “load more comments”,
     # and “continue this thread” links encountered on the website.
@@ -53,10 +54,26 @@ def is_asshole(submission: praw.models.reddit.submission.Submission):
             continue
         if commenter_thinks_OP_is_ass:
             votes_for_YTA += 1
+            upvotes_for_YTA += comment.ups
         else:
             votes_for_NTA += 1
+            upvotes_for_NTA += 1
 
-    return int(votes_for_YTA > votes_for_NTA)
+    return int(votes_for_YTA > votes_for_NTA), {'YTA_votes': votes_for_YTA,
+                                                'YTA_upvotes': upvotes_for_YTA,
+                                                'NTA_votes': votes_for_NTA,
+                                                'NTA_upvotes': upvotes_for_NTA,
+                                                }
+
+
+def is_post_asking_AITA(title, text):
+    title = title.lower()
+    text = text.lower()
+    if 'meta' in title or 'update' in title:
+        return False
+    if text == '[removed]' or text == '[deleted]':
+        return False
+    return True
 
 
 if __name__ == '__main__':
@@ -71,39 +88,39 @@ if __name__ == '__main__':
                          user_agent=config.REDDIT_USER_AGENT,
                          username=config.REDDIT_USERNAME,
                          )
-    api = PushshiftAPI(reddit)  # this allows for pagination of praw results
     logging.info('connection successful')
 
-    num_posts = 12_000
-    data_path = Path(f'./data/raw/{num_posts}.csv')
+    num_posts = 100
+    data_path = Path(f'./data/raw/best-{num_posts}.csv')
     with data_path.open('w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f, delimiter=',', quotechar='|')
-        writer.writerow(['is_asshole', 'title', 'text'])
+        writer.writerow(['is_asshole', 'YTA_votes', 'YTA_upvotes', 'NTA_votes', 'NTA_upvotes', 'title', 'text'])
 
         total_submissions = 0
         num_assholes = 0
 
         # we'll to paginate based on time. praw took away the ability to paginate on id :(
-        start_epoch = datetime.datetime.now()
+        latest_fullname = None
         while total_submissions < num_posts:
-            end_epoch = start_epoch -  datetime.timedelta(days=10)
-            submissions = api.search_submissions(limit=None,
-                                                 before=int(start_epoch.timestamp()),
-                                                 after=int(end_epoch.timestamp()),
-                                                 subreddit='AmITheAsshole',
-                                                 )
-            start_epoch = end_epoch
-
+            submissions = reddit.subreddit("AmITheAsshole").top(limit=10,
+                                                                params={'after': latest_fullname},
+                                                                )
             for submission in submissions:
+                latest_fullname = submission.fullname
                 title = submission.title
-                id_num = submission.id
-                text = submission.selftext.replace('\n', '')
-                if text == '[removed]' or text == '[deleted]':
+                if not is_post_asking_AITA():
+                    # these aren't the posts we're looking for
                     continue
-                annotation = is_asshole(submission)
+                id_num = submission.id
+                text = submission.selftext.replace('\n', ' ')
+
+                annotation, info = is_asshole(submission)
                 if annotation:
                     num_assholes += 1
-                writer.writerow([annotation, title, text])
+                writer.writerow([annotation,
+                                 info['YTA_votes'], info['YTA_upvotes'],
+                                 info['NTA_votes'], info['NTA_upvotes'],
+                                 title, text])
                 total_submissions += 1
                 if total_submissions % 100 == 0:
                     logging.info(f'{total_submissions} instances complete. {num_assholes} assholes found. '

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -6,64 +6,51 @@ and output to file
 '''
 import csv
 import logging
+from collections import Counter
 from pathlib import Path
 
 import praw
 from praw.models import MoreComments
 
 from src import config
+from src.class_enum import ClassEnum
 
 
-def does_commenter_think_OP_is_an_ass(comment_text: str) -> bool:
+
+def does_commenter_think_OP_is_an_ass(comment_text: str):
     """
     given the text from a comment, determine if the commenter thinks OP is an asshole or not
     :param comment_text: the commenter's text
-    :return: True if the commenter thinks OP is an asshole
+    :return: The enum corresponding to the type of comment
     """
-    if 'YTA' in comment_text:
-        return True
-    if 'NTA' in comment_text:
-        return False
+    for type in ClassEnum:
+        if type.name in comment_text:
+            return type
     return None
 
 
 def is_asshole(submission: praw.models.reddit.submission.Submission):
     """
     iterate through the comments to find signals for asshole or not
-    NTA = not the asshole
-    YTA = you're the asshole
+    see src\class_enum.py for possible types
     :param submission: a praw.models.reddit.submission.Submission object
     :return: True if more comments have 'YTA' than 'NTA'
     """
-    votes_for_NTA = 0
-    votes_for_YTA = 0
-
-    upvotes_for_NTA = 0
-    upvotes_for_YTA = 0
-
-    # This submission’s comment forest contains a number of MoreComments objects.
-    # These objects represent the “load more comments”,
-    # and “continue this thread” links encountered on the website.
-    # To remove them, we can call replace_more with a limit of 0
-    # to remove ALL MoreComments
+    # following the subreddit's rules, we take the top voted comment to be the annotation
+    # see more [here](https://www.reddit.com/r/AmItheAsshole/wiki/faq#wiki_why_do_you_use_upvotes_to_determine_the_winning_judgment.3F_why_don.2019t_you_count_up_the_nta_and_yta_in_each_thread.3F)
+    commenter_thinks_OP_is = None
+    submission.comment_sort = 'top'
     submission.comments.replace_more(limit=0)
     for comment in submission.comments:
         text = comment.body
-        commenter_thinks_OP_is_ass = does_commenter_think_OP_is_an_ass(text)
-        if commenter_thinks_OP_is_ass is None:
+        commenter_thinks_OP_is = does_commenter_think_OP_is_an_ass(text)
+        if commenter_thinks_OP_is is None:
+            # skip over moderator comments (default to top position)
             continue
-        if commenter_thinks_OP_is_ass:
-            votes_for_YTA += 1
-            upvotes_for_YTA += comment.ups
-        else:
-            votes_for_NTA += 1
-            upvotes_for_NTA += 1
+        # we've found the top comment that labels OP as a class
+        break
 
-    return int(votes_for_YTA > votes_for_NTA), {'YTA_votes': votes_for_YTA,
-                                                'YTA_upvotes': upvotes_for_YTA,
-                                                'NTA_votes': votes_for_NTA,
-                                                'NTA_upvotes': upvotes_for_NTA,
-                                                }
+    return commenter_thinks_OP_is
 
 
 def is_post_asking_AITA(title, text):
@@ -91,24 +78,23 @@ if __name__ == '__main__':
     # api = PushshiftAPI(reddit)  # this allows for pagination of praw results
     logging.info('connection successful')
 
-    num_posts = 900
+    num_posts = 850
     data_path = Path(f'./data/raw/top-{num_posts}.csv')
     with data_path.open('w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f, delimiter=',', quotechar='|')
         writer.writerow(['fullname', 'is_asshole',
-                         'YTA_votes', 'YTA_upvotes',
-                         'NTA_votes', 'NTA_upvotes',
                          'post_upvotes',
                          'title', 'text'])
 
         total_submissions = 0
-        num_assholes = 0
+        annotations = []
 
         # we'll to paginate based on time. praw took away the ability to paginate on id :(
         latest_fullname = None
         while total_submissions < num_posts:
             submissions = reddit.subreddit("AmITheAsshole").top(limit=100,
-                                                                params={'after': latest_fullname},
+                                                                params={'after': latest_fullname,
+                                                                        'comment_sort': 'top'},
                                                                 )
             # end_epoch = start_epoch -  datetime.timedelta(days=10)
             # submissions = api.search_submissions(limit=None,
@@ -126,18 +112,23 @@ if __name__ == '__main__':
                     continue
 
                 latest_fullname = submission.fullname
-                annotation, info = is_asshole(submission)
-                if annotation:
-                    num_assholes += 1
-                writer.writerow([latest_fullname, annotation,
-                                 info['YTA_votes'], info['YTA_upvotes'],
-                                 info['NTA_votes'], info['NTA_upvotes'],
+                annotation = is_asshole(submission)
+                annotations.append(annotation.name)
+                writer.writerow([latest_fullname, annotation.name,
                                  submission.ups,
                                  title, text])
                 total_submissions += 1
                 if total_submissions % 100 == 0:
-                    logging.info(f'{total_submissions} instances complete. {num_assholes} assholes found. '
-                                 f'{num_assholes / total_submissions * 100}%')
-
-    logging.info(f'num assholes: {num_assholes} out of {total_submissions} total posts. '
-                 f'Percent {num_assholes / total_submissions}')
+                    c = Counter(annotations)
+                    percentage_dict = {key: val / total_submissions for key, val in c.items()}
+                    logging.info(f'{total_submissions} instances complete. \n'
+                                 f'{c}\n'
+                                 f'        '
+                                 f'{percentage_dict}')
+    c = Counter(annotations)
+    percentage_dict = {key: val / total_submissions for key, val in c.items()}
+    logging.info(f'{total_submissions} total posts. '
+                 f'{c}\n'
+                 f'        '
+                 f'{percentage_dict}'
+                 )

--- a/src/reddit_data_module.py
+++ b/src/reddit_data_module.py
@@ -5,6 +5,8 @@ import pytorch_lightning as pl
 from torch.utils.data import random_split, DataLoader, Dataset
 from transformers import BertTokenizer
 
+from class_enum import ClassEnum
+
 
 class RedditDataSet(Dataset):
     def __init__(self, csv_file, transform):
@@ -21,7 +23,7 @@ class RedditDataSet(Dataset):
             for instance in reader:
                 d = {headers[i]: instance[i] for i in range(len(headers))}
                 # need to convert the strings to ints: '0' -> 0
-                d['is_asshole'] = int(d['is_asshole'])
+                d['is_asshole'] = ClassEnum[d['is_asshole']].value
                 yield d
 
     def __len__(self):

--- a/src/train.py
+++ b/src/train.py
@@ -9,19 +9,21 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 
 from model import AssholeClassifier
 from reddit_data_module import RedditDataModule
+from class_enum import ClassEnum
 
 if __name__ == '__main__':
-    exp_name = 'title-lr=.3'
+    exp_name = 'title-lr=.3-epochs-50'
     torch.manual_seed(2)
     train_dir = os.path.join('..', 'data', 'raw')
     data_module = RedditDataModule(data_dir=train_dir,
-                                   data_filename='10000.csv')
+                                   data_filename='top-850.csv')
+    possible_labels = [label.name for label in ClassEnum]
     model = AssholeClassifier(learning_rate=.3,
-                              possible_labels=[0, 1])
+                              possible_labels=possible_labels)
     trainer = pl.Trainer(
         default_root_dir='logs',
         gpus=0,  # (1 if torch.cuda.is_available() else 0),
-        max_epochs=10,
+        max_epochs=50,
         fast_dev_run=exp_name == 'debug',
         logger=pl.loggers.TensorBoardLogger('logs', name=exp_name, version=0),
         callbacks=[ModelCheckpoint(save_top_k=-1,


### PR DESCRIPTION
Instead of a binary classification task on asshole/not, we now include the other possible annotations. This means that data in the previous sets was  likely mislabeled. 

The data generated has a pretty high class imbalance. We'll likely need to weight the loss function to have chance at getting a  model that doesn't just classify everything as NTA. 

In this PR:
- enum for all class types
- preprocessing script  updated to match the AITA subreddit rules (only consider the top post to determine the class. Bots could be used to auto-comment, skewing the votes)
- using `reddit` api instead of pushshift - we get limited by the data, but we can sort by top this way. Hoping for better data quality over data quantity.